### PR TITLE
:wrench: Tweak a few configuration files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "prettier.packageManager": "yarn",
   "prettier.printWidth": 120,
   "prettier.singleQuote": true,
+  "files.eol": "\n",
   "prettier.trailingComma": "es5"
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: '3.7'
 
 services:
   postgresql:
@@ -7,6 +7,9 @@ services:
     build:
       context: ./database
     ports:
-      - "5432:5432"
+      - '5432:5432'
     volumes:
-      - ../.volumes/postgresql:/var/lib/postgresql/data
+      - postgresql:/var/lib/postgresql/data
+
+volumes:
+  postgresql:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     }
   },
   "engines": {
-    "node": "12.14.0"
+    "node": "^13.5.0"
   },
   "dependencies": {
     "bookshelf": "^1.0.1",

--- a/scripts/commitmsg
+++ b/scripts/commitmsg
@@ -20,7 +20,7 @@ const fetchAndCacheGitmojis = async () => {
 
     console.info('Saving gitmojis cache');
     if (!existsSync(CACHE_FOLDER_PATH)) {
-      mkdirSync(path.dirname(CACHE_FOLDER_PATH));
+      mkdirSync(CACHE_FOLDER_PATH);
     }
 
     writeFileSync(CACHE_FILE_PATH, JSON.stringify(emojis));


### PR DESCRIPTION
- Add Node v13.5.x support
- Move around the docker volume to be internal as it should be
- Fix the line ending for the VSCode project
- Fix the commit hook, the filepath was wrong when cache directory
didn't exist, it was attempting to create /home/user and fail because
it was already existing. Not using path.dirname fixes it.